### PR TITLE
Added 0 padding to fiat currency display

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -167,7 +167,7 @@ const App = () => {
           </Typography>
           <Typography variant="h6" component="p" onClick={() => setLocalCurrency(localCurrency === 'USD' ? 'GBP' : 'USD')}>
             {getCurrencySymbol(localCurrency)}
-            {parseFloat((getTotalBalance() * (exchangeRate || 0)).toFixed(2)).toLocaleString()}
+            {parseFloat(getTotalBalance() * (exchangeRate || 0)).toFixed(2).toLocaleString()}
           </Typography>
         </div>
         { showAccounts }


### PR DESCRIPTION
Looks like the `toFixed(2)` function being called inside the `parseFloat()` function was causing the intended 0-padding to be erased by `parseFloat`. Now `$59.1` appears as `$59.10`.

Unintended side effect: `$0` is now displayed `$0.00`.

Cheers!